### PR TITLE
Updated SES library dependency to one that supports SES Signature v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Used to send Parse Server password reset and email verification emails with Amaz
 Read more here: https://github.com/ParsePlatform/parse-server.
 
 ## Compatibility
-Tested with Parse Server v2.2.13
+Last tested with Parse Server v3.10
 
 ## Install
 ```sh
@@ -23,7 +23,7 @@ var parse=new ParseServer({
          from: "Your Name <noreply@yourdomain.com>",
          accessKeyId: "Your AWS IAM Access Key ID",
          secretAccessKey: "Your AWS IAM Secret Access Key",
-         region: "Your AWS Region"
+         awsEndpoint: "AWS end point. Defaults to `https://email.us-east-1.amazonaws.com`"
       }
    }
 });

--- a/index.js
+++ b/index.js
@@ -1,28 +1,25 @@
-var AmazonSES = require("amazon-ses-mailer");
+var AmazonSES = require("node-ses");
 
-module.exports=function(options){
+module.exports = function (options) {
 
-   var ses = new AmazonSES(
-      options.accessKeyId,
-      options.secretAccessKey,
-      options.region
-   );
+   var sesClient = AmazonSES.createClient({
+      key: options.accessKeyId,
+      secret: options.secretAccessKey,
+      amazon: options.awsEndpoint,
+   });
 
-   var sendMail=function(mail){
+   var sendMail = function (mail) {
 
-      return new Promise(function(resolve, reject){
+      return new Promise(function (resolve, reject) {
 
-         ses.send({
-            from: options.from,
+         sesClient.sendEmail({
             to: [mail.to],
+            from: options.from,
             subject: mail.subject,
-            body: {
-               text: mail.text
-            }
-         }, function(error, data) {
-
-            if (error) {
-               reject(error);
+            message: mail.text
+         }, function (err, data) {
+            if (err) {
+               reject(err);
             } else {
                resolve(data);
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parse-server-amazon-ses-adapter",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Used to send Parse Server password reset and email verification emails with Amazon SES.",
   "main": "index.js",
   "scripts": {
@@ -26,6 +26,6 @@
   },
   "homepage": "https://github.com/collinbrewer/parse-server-amazon-ses-adapter#readme",
   "dependencies": {
-    "amazon-ses-mailer": "^0.2.0"
+    "node-ses": "^3.0.3"
   }
 }


### PR DESCRIPTION
This SES adapter was depending on the outdated `amazon-ses-mailer` package. The old package was using the SES v3 signing and Amazon started blocking those requests in March 2021.

This PR updates the dependency to a new package `node-ses` which uses v4 signing. It was a pretty straightforward rewrite to use the new package. 

Tested on my v3.10 Parse server instance. The API is pretty straightforward so I imagine it should work without problem on newer Parse Server versions.